### PR TITLE
fix: some more BigInteger->long conversion issues

### DIFF
--- a/src/main/java/dev/ftb/extendedexchange/client/gui/EMCFormat.java
+++ b/src/main/java/dev/ftb/extendedexchange/client/gui/EMCFormat.java
@@ -3,6 +3,7 @@ package dev.ftb.extendedexchange.client.gui;
 import dev.ftb.extendedexchange.config.ConfigHelper;
 import net.minecraft.client.gui.screens.Screen;
 
+import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.FieldPosition;
@@ -20,6 +21,26 @@ public class EMCFormat extends DecimalFormat {
         super("#,###");
         setRoundingMode(RoundingMode.DOWN);
         ignoreShift = is;
+    }
+
+    public static String formatBigDecimal(BigDecimal d) {
+        String s = d.toString();
+        if (s.length() >= 25) {
+            s = s.substring(0, s.length() - 24) + "Y";
+        } else if (s.length() >= 22) {
+            s = s.substring(0, s.length() - 21) + "Z";
+        } else if (s.length() >= 19) {
+            s = s.substring(0, s.length() - 18) + "E";
+        } else if (s.length() >= 16) {
+            s = s.substring(0, s.length() - 15) + "P";
+        } else if (s.length() >= 13) {
+            s = s.substring(0, s.length() - 12) + "T";
+        } else if (s.length() >= 10) {
+            s = s.substring(0, s.length() - 9) + "G";
+        } else if (s.length() >= 7) {
+            s = s.substring(0, s.length() - 6) + "M";
+        }
+        return s;
     }
 
     @Override

--- a/src/main/java/dev/ftb/extendedexchange/client/gui/buttons/ExtractItemButton.java
+++ b/src/main/java/dev/ftb/extendedexchange/client/gui/buttons/ExtractItemButton.java
@@ -15,6 +15,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import org.lwjgl.opengl.GL11;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 public class ExtractItemButton extends EXButton {
@@ -61,16 +63,18 @@ public class ExtractItemButton extends EXButton {
         }
     }
 
+    private static final BigDecimal ONE_TENTH = BigDecimal.valueOf(1L, 1);
     private String getExtractionCountStr() {
         long emc = ProjectEAPI.getEMCProxy().getValue(item);
         if (emc == 0L) return "???"; // shouldn't happen, but...
 
         String label = "";
-        double d = provider.getEmc().longValue() / (double) emc;
-        if (d >= 1D) {
-            label = EMCFormat.INSTANCE_IGNORE_SHIFT.format(d);
-        } else if (d >= 0.1D) {
-            label = Double.toString(((int) (d * 10D)) / 10D);
+        BigDecimal d = new BigDecimal(provider.getEmc()).setScale(1, RoundingMode.DOWN)
+                .divide(BigDecimal.valueOf(emc), RoundingMode.DOWN);
+        if (d.compareTo(BigDecimal.ONE) >= 0) {
+            label = EMCFormat.formatBigDecimal(d.setScale(0, RoundingMode.DOWN));
+        } else if (d.compareTo(ONE_TENTH) >= 0) {
+            label = d.toString();
         }
         return label;
     }

--- a/src/main/java/dev/ftb/extendedexchange/config/ConfigHelper.java
+++ b/src/main/java/dev/ftb/extendedexchange/config/ConfigHelper.java
@@ -3,7 +3,11 @@ package dev.ftb.extendedexchange.config;
 import dev.ftb.extendedexchange.EXTags;
 import net.minecraft.world.item.ItemStack;
 
+import java.math.BigInteger;
+
 public class ConfigHelper {
+    static BigInteger emcLinkMaxOutput;
+
     public static ClientConfig client() {
         return ConfigHolder.client;
     }
@@ -18,5 +22,9 @@ public class ConfigHelper {
 
     public static boolean isStoneTableWhitelisted(ItemStack stack) {
         return !server().general.enableStoneTableWhitelist.get() || stack.is(EXTags.Items.STONE_TABLE_WHITELIST);
+    }
+
+    public static BigInteger getEMCLinkMaxOutput() {
+        return emcLinkMaxOutput;
     }
 }

--- a/src/main/java/dev/ftb/extendedexchange/config/ConfigHolder.java
+++ b/src/main/java/dev/ftb/extendedexchange/config/ConfigHolder.java
@@ -24,6 +24,8 @@ import net.minecraftforge.fml.event.config.ModConfigEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.apache.commons.lang3.tuple.Pair;
 
+import java.math.BigInteger;
+
 public class ConfigHolder {
     static ClientConfig client;
     static ServerConfig server;
@@ -55,6 +57,7 @@ public class ConfigHolder {
     }
 
     private static void refreshServer() {
+        ConfigHelper.emcLinkMaxOutput = BigInteger.valueOf(ConfigHelper.server().general.emcLinkMaxOutput.get());
     }
 
     private static void refreshClient() {

--- a/src/main/java/dev/ftb/extendedexchange/util/EXUtils.java
+++ b/src/main/java/dev/ftb/extendedexchange/util/EXUtils.java
@@ -11,8 +11,13 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
 
+import java.math.BigInteger;
+
 public class EXUtils {
     public static final Direction[] DIRECTIONS = Direction.values();
+
+    private static final BigInteger MAX_LONG = BigInteger.valueOf(Long.MAX_VALUE);
+    private static final BigInteger MAX_INT = BigInteger.valueOf(Integer.MAX_VALUE);
 
     public static ResourceLocation rl(String path) {
         return new ResourceLocation(ExtendedExchange.MOD_ID, path);
@@ -42,6 +47,10 @@ public class EXUtils {
 
     public static boolean playerHasKnowledge(Player player, ItemStack stack) {
         return ProjectEAPI.getTransmutationProxy().getKnowledgeProviderFor(player.getUUID()).hasKnowledge(stack);
+    }
+
+    public static int bigIntToInt(BigInteger n) {
+        return n.compareTo(MAX_INT) > 0 ? Integer.MAX_VALUE : n.intValueExact();
     }
 
     public enum KnowledgeAddResult {


### PR DESCRIPTION
Dropped all uses of `.longValue()` ; that should never be used since it can result in negative values.  Cap the result at Long.MAX_VALUE or Integer.MAX_VALUE as appropriate.