### PR TITLE
fix: excessive EMC sync packets to clients

### DIFF
--- a/src/main/java/dev/ftb/extendedexchange/EMCSyncHandler.java
+++ b/src/main/java/dev/ftb/extendedexchange/EMCSyncHandler.java
@@ -1,0 +1,46 @@
+package dev.ftb.extendedexchange;
+
+import moze_intel.projecte.api.capabilities.PECapabilities;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.server.ServerLifecycleHooks;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Track players who need their EMC value sync'd, and do it in a controlled fashion once a second instead of every time
+ * an EMC link block does anything. Avoids excessive sync'ing and performance issues with many such blocks in the world.
+ */
+public enum EMCSyncHandler {
+    INSTANCE;
+
+    private final Set<UUID> toSync = new HashSet<>();  // UUID of players who need EMC sync'd
+    private int counter = 0;
+
+    public void needsSync(ServerPlayer player) {
+        toSync.add(player.getUUID());
+    }
+
+    public void needsSync(UUID playerId) {
+        toSync.add(playerId);
+    }
+
+    public void onServerTick(TickEvent.ServerTickEvent event) {
+        if (event.phase == TickEvent.Phase.END) {
+            counter++;
+            if (counter == 20) {
+                MinecraftServer server = ServerLifecycleHooks.getCurrentServer();
+                toSync.stream()
+                        .map(id -> server.getPlayerList().getPlayer(id))
+                        .filter(player -> player != null && player.isAlive())
+                        .forEach(player -> player.getCapability(PECapabilities.KNOWLEDGE_CAPABILITY)
+                                .ifPresent(provider -> provider.syncEmc(player)));
+                toSync.clear();
+                counter = 0;
+            }
+        }
+    }
+}

--- a/src/main/java/dev/ftb/extendedexchange/ExtendedExchange.java
+++ b/src/main/java/dev/ftb/extendedexchange/ExtendedExchange.java
@@ -41,6 +41,7 @@ public class ExtendedExchange {
         modBus.addListener(this::commonSetup);
 
         forgeBus.addListener(this::addReloadListeners);
+        forgeBus.addListener(EMCSyncHandler.INSTANCE::onServerTick);
     }
 
     private void commonSetup(FMLCommonSetupEvent event) {

--- a/src/main/java/dev/ftb/extendedexchange/block/entity/AbstractLinkBlockEntity.java
+++ b/src/main/java/dev/ftb/extendedexchange/block/entity/AbstractLinkBlockEntity.java
@@ -1,5 +1,6 @@
 package dev.ftb.extendedexchange.block.entity;
 
+import dev.ftb.extendedexchange.EMCSyncHandler;
 import moze_intel.projecte.api.capabilities.PECapabilities;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
@@ -74,7 +75,7 @@ public class AbstractLinkBlockEntity extends AbstractEMCBlockEntity {
                         provider.setEmc(provider.getEmc().add(BigInteger.valueOf(storedEMC)));
                         storedEMC = 0L;
                         setChanged();
-                        provider.syncEmc(player);
+                        EMCSyncHandler.INSTANCE.needsSync(player);
                     });
                 }
             }
@@ -137,11 +138,6 @@ public class AbstractLinkBlockEntity extends AbstractEMCBlockEntity {
     }
 
     public void trySyncEMC() {
-        if (level != null && !level.isClientSide && level.getServer() != null) {
-            ServerPlayer player = level.getServer().getPlayerList().getPlayer(getOwnerId());
-            if (player != null) {
-                player.getCapability(PECapabilities.KNOWLEDGE_CAPABILITY).ifPresent(provider -> provider.syncEmc(player));
-            }
-        }
+        EMCSyncHandler.INSTANCE.needsSync(getOwnerId());
     }
 }


### PR DESCRIPTION
Don't just sync EMC every time a player's EMC changes; that leads to lag if many machines are altering EMC. Instead mark player as needing sync'ing, and check for that every 20 ticks.

https://github.com/FTBTeam/FTB-Modpack-Issues/issues/2054