### PR TITLE
Add config option to limit returned stack size for EMC Links

### DIFF
--- a/src/main/java/dev/ftb/extendedexchange/config/ConfigHelper.java
+++ b/src/main/java/dev/ftb/extendedexchange/config/ConfigHelper.java
@@ -28,5 +28,7 @@ public class ConfigHelper {
         return emcLinkMaxOutput;
     }
 
-    public static int getEMCLinkMaxStackSize() { return server().general.emcLinkMaxStackSize.get(); }
+    public static int getEMCLinkMaxStackSize() {
+        return server().general.emcLinkMaxStackSize.get();
+    }
 }

--- a/src/main/java/dev/ftb/extendedexchange/config/ConfigHelper.java
+++ b/src/main/java/dev/ftb/extendedexchange/config/ConfigHelper.java
@@ -27,4 +27,6 @@ public class ConfigHelper {
     public static BigInteger getEMCLinkMaxOutput() {
         return emcLinkMaxOutput;
     }
+
+    public static int getEMCLinkMaxStackSize() { return server().general.emcLinkMaxStackSize.get(); }
 }

--- a/src/main/java/dev/ftb/extendedexchange/config/ServerConfig.java
+++ b/src/main/java/dev/ftb/extendedexchange/config/ServerConfig.java
@@ -5,6 +5,7 @@ import net.minecraftforge.common.ForgeConfigSpec;
 public class ServerConfig {
     public static class General {
         public ForgeConfigSpec.LongValue emcLinkMaxOutput;
+        public ForgeConfigSpec.IntValue emcLinkMaxStackSize;
         public ForgeConfigSpec.BooleanValue enableStoneTableWhitelist;
         public ForgeConfigSpec.BooleanValue finalStarCopiesAnyItem;
         public ForgeConfigSpec.BooleanValue finalStarCopiesNBT;
@@ -19,6 +20,9 @@ public class ServerConfig {
         general.emcLinkMaxOutput = builder
                 .comment("Max EMC which Personal/Refined/Compressed Refined Link Blocks can remove from personal EMC (in one operation) when extracting items. Setting this to 0 disables extraction of any item from these blocks.")
                 .defineInRange("emc_link_max_output", 2_000_000_000L, 0, Long.MAX_VALUE);
+        general.emcLinkMaxStackSize = builder
+                .comment("Max stack size which Personal/Refined/Compressed Refined Link Blocks will return when extracting items. Setting this to 0 disables extraction of any item from these blocks.")
+                .defineInRange("emc_link_max_stack_size", 2_000_000_000, 0, Integer.MAX_VALUE);
         general.enableStoneTableWhitelist = builder
                 .comment("If false, ignore the Stone Table whitelist, which is the 'extendedexchange:stone_table_whitelist' item tag. If true, only items in that tag can be placed in the Stone Table.")
                 .define("enable_stone_table_whitelist", false);

--- a/src/main/java/dev/ftb/extendedexchange/inventory/LinkOutputHandler.java
+++ b/src/main/java/dev/ftb/extendedexchange/inventory/LinkOutputHandler.java
@@ -121,7 +121,7 @@ public class LinkOutputHandler extends BaseItemStackHandler<AbstractLinkInvBlock
             return 0;
         } else {
             BigInteger itemCount = value == 1 ? cappedEMC : cappedEMC.divide(BigInteger.valueOf(value));
-            return EXUtils.bigIntToInt(itemCount);
+            return EXUtils.bigIntToInt(itemCount.min(BigInteger.valueOf(ConfigHelper.getEMCLinkMaxStackSize())));
         }
     }
 }


### PR DESCRIPTION
By default the stacks are limited to 2 billion items, which realistically should never cause an issue for autocrafting and other usage. This is a separate config option from the `emc_link_max_output` option.